### PR TITLE
bug-11: Spinner variables size explicitly defined

### DIFF
--- a/docs/classes/Spinner.md
+++ b/docs/classes/Spinner.md
@@ -35,7 +35,7 @@ When an spin map is assigned to a spinning process, an integrity check is done b
 
 1. A map must have at least two spin points.
 2. The first map point must have its time set to zero.
-3. The elapsed time of an spin point cannot be lower than its predecessor.
+3. The elapsed time of an spin point cannot be lower than the preceding point time.
 
 
 ## How Spinner works
@@ -94,11 +94,11 @@ Spinner spinner(&motor);
 // and the elapsed time (milliseconds) from the spin start.
 void spinUpdated(const SpinPoint *spinPoint)
 {
-    Serial.print("Spin updated. ");
-    Serial.print("Speed: ");
-    Serial.print(spinPoint->speed);
-    Serial.print(" Elapsed time: ");
-    Serial.println(spinPoint->time);
+  Serial.print("Spin updated. ");
+  Serial.print("Speed: ");
+  Serial.print(spinPoint->speed);
+  Serial.print(" Elapsed time: ");
+  Serial.println(spinPoint->time);
 }
 
 // Callback function for the spinner event of spin finished
@@ -109,11 +109,11 @@ void spinUpdated(const SpinPoint *spinPoint)
 // that could be higher to that set in the spin map last point.
 void spinFinished(const SpinPoint *spinPoint)
 {
-    Serial.print("Spin finished");
-    Serial.print("Final speed: ");
-    Serial.print(spinPoint->speed);
-    Serial.print(" Overall spin ellapsed time: ");
-    Serial.println(spinPoint->time);
+  Serial.print("Spin finished");
+  Serial.print("Final speed: ");
+  Serial.print(spinPoint->speed);
+  Serial.print(" Overall spin ellapsed time: ");
+  Serial.println(spinPoint->time);
 }
 
 // Define digital IO ids
@@ -152,13 +152,14 @@ Pointer to a `SpinPoint` struct containing the last reached spin map point, or `
 ```C++
 SpinPoint currentSpinPoint = spinner.abort();
 if (currentSpinPoint) {
-    Serial.print("Current spin speed when aborted: ");
-    Serial.print(spinPoint->speed);
-    Serial.print(" Elapsed time when aborted: ");
-    Serial.println(spinPoint->time);
+  Serial.print("Spin operation aborted.");
+  Serial.print(" Current speed: ");
+  Serial.print(spinPoint->speed);
+  Serial.print(" Elapsed time: ");
+  Serial.println(spinPoint->time);
 }
 else {
-    Serial.print("No spin operation aborted");
+  Serial.print("No spin operation aborted");
 }
 ```
 
@@ -247,7 +248,6 @@ enum Direction
 }
 ```
 
-
 # Structs
 
 ## SpinPoint
@@ -256,10 +256,10 @@ Represents a duple speed-time in a spinning process, ie, the motor speed (from 1
 ```C++
 struct SpinPoint
 {
-    byte speed;
-    unsigned int time;
+    uint8_t speed;
+    uint16_t time;
 };
 ```
 
 * Field `speed` represents the motor speed in a scale from 1 to 255.
-* Field `time` represents the elapsed time, in milliseconds, after start spinning in which speed is achieved.
+* Field `time` represents the elapsed time, from 1 to 65535 milliseconds, after start spinning in which `speed` is reached.

--- a/src/Spinner.cpp
+++ b/src/Spinner.cpp
@@ -65,7 +65,7 @@ const SpinPoint *Spinner::start(Direction direction, SpinPoint spinMap[])
  */
 const SpinPoint *Spinner::spin()
 {
-    unsigned short currentmapPointIndex;
+    uint8_t currentmapPointIndex;
 
     // If there's no map, there's no spin in progress: quit
     if (map_ == NULL)
@@ -84,7 +84,7 @@ const SpinPoint *Spinner::spin()
     currentmapPointIndex = refreshSpinCourse_(map_, mapSize_, spinElapsedTime);
 
     // Set the new speed
-    byte newSpeed;
+    uint8_t newSpeed;
     if (currentmapPointIndex == mapSize_ - 1)
     {
         // The spin is beyond the latest map point: the operation is finished
@@ -148,10 +148,10 @@ const SpinPoint *Spinner::abort()
 /**
  * Checks the integrity of a spin map
  * @param {SpinPoint[]} spinMap - Spin map
- * @param {uint16_t} mapSize_ - Spin map items
+ * @param {uint8_t} mapSize_ - Spin map items
  * @returns {bool} True if the spin map passes the integrity checks
  */
-bool Spinner::checkSpinMap_(SpinPoint spinMap[], unsigned short mapSize_)
+bool Spinner::checkSpinMap_(SpinPoint spinMap[], uint8_t mapSize_)
 {
 #ifdef TB6612FNG_OMIT_SPINMAP_INTEGRITY_CHECK
     return true;
@@ -165,7 +165,7 @@ bool Spinner::checkSpinMap_(SpinPoint spinMap[], unsigned short mapSize_)
         return false;
 
     // Every map point time must be higher than its predecessor's
-    uint32_t previousSpinTime = spinMap[0].time;
+    uint16_t previousSpinTime = spinMap[0].time;
     for (int i = 1; i < mapSize_; i++)
     {
         if (spinMap[i].time <= previousSpinTime)
@@ -212,13 +212,13 @@ void Spinner::updateSpeed_(Motor *motor, Direction spinDirection, SpinPoint *spi
 /**
  * Returns the last reached spin map point given an elapsed time since the spin start
  * @param {SpinPoint*} map - Spin map, or array of spin points
- * @param {unsigned short} mapCount - Size of the spin map, ie, number of map points stored in the spin map
+ * @param {uint8_t} mapCount - Size of the spin map, ie, number of map points stored in the spin map
  * @param {unsigned long} elapsedTime - Elapsed time, in milliseconds, since the spin start
- * @returns {unsigned short} Index of the next map spin point
+ * @returns {uint8_t} Index of the next map spin point
  */
-unsigned short Spinner::refreshSpinCourse_(SpinPoint map[], unsigned short mapCount, unsigned long elapsedTime)
+uint8_t Spinner::refreshSpinCourse_(SpinPoint map[], uint8_t mapCount, unsigned long elapsedTime)
 {
-    unsigned short mapPoint = 0;
+    uint8_t mapPoint = 0;
     while (mapPoint < mapCount && elapsedTime > map[mapPoint].time)
     {
         mapPoint++;
@@ -228,14 +228,14 @@ unsigned short Spinner::refreshSpinCourse_(SpinPoint map[], unsigned short mapCo
 
 /**
  * Returns the Y coordinate of a point in a line given its X coordinate
- * @param {unsigned int} x1 - X coordinate of the line point 1
- * @param {unsigned int} y1 - Y coordinate of the line point 1
- * @param {unsigned int} x2 - X coordinate of the line point 2
- * @param {unsigned int} y2 - Y coordinate of the line point 2
- * @param {unsigned int} x - X coordinate of the line point whose Y coordinate must be obtained
- * @return {unsigned int} Y coordinate of the line point with X coordinate equal to x
+ * @param {uint16_t} x1 - X coordinate of the line point 1
+ * @param {uint16_t} y1 - Y coordinate of the line point 1
+ * @param {uint16_t} x2 - X coordinate of the line point 2
+ * @param {uint16_t} y2 - Y coordinate of the line point 2
+ * @param {uint16_t} x - X coordinate of the line point whose Y coordinate must be obtained
+ * @return {uint16_t} Y coordinate of the line point with X coordinate equal to x
  */
-unsigned int Spinner::getLinePointY_(unsigned int x1, unsigned int y1, unsigned int x2, unsigned int y2, unsigned int x)
+uint16_t Spinner::getLinePointY_(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2, uint16_t x)
 {
     return y1 + round(((double)x / (x2 - x1)) * (y2 - y1));
 }

--- a/src/Spinner.h
+++ b/src/Spinner.h
@@ -11,14 +11,14 @@
 /**
  * Spin point
  * @typedef {struct} SpinPoint
- * @property {byte}} speed - Spin speed, from 1 to 255
- * @property {unsigned int}} time - Elapsed time from the spin start, in milliseconds, in which speed must be reached
+ * @property {uint8_t}} speed - Spin speed, from 1 to 255
+ * @property {uint16_t} time - Elapsed time from the spin start, from 0 to 65535 milliseconds, in which speed must be reached
  * @example A spinPoint with value {20,100} indicates that, after 100 milliseconds of start spinning, a speed of 20 must be reached
  */
 struct SpinPoint
 {
-    byte speed;
-    unsigned int time;
+    uint8_t speed;
+    uint16_t time;
 };
 
 /**
@@ -77,21 +77,21 @@ private:
     Motor *motor_;
 
     SpinPoint *map_;
-    unsigned short mapSize_;
+    uint8_t mapSize_;
 
     Direction spinDirection_;
     unsigned long spinStartTime_;
     SpinPoint currentSpinPoint_;
 
-    unsigned short currentMapPointIndex_;
+    uint8_t currentMapPointIndex_;
 
     SpinnerCB spinUpdatedCB_, spinFinishedCB_;
 
-    bool checkSpinMap_(SpinPoint[], unsigned short);
+    bool checkSpinMap_(SpinPoint[], uint8_t;
     unsigned long getElapsedTime_(unsigned long);
     void updateSpeed_(Motor *, Direction, SpinPoint *, SpinnerCB);
-    unsigned short refreshSpinCourse_(SpinPoint *, unsigned short, unsigned long);
-    unsigned int getLinePointY_(unsigned int x1, unsigned int y1, unsigned int x2, unsigned int y2, unsigned int x);
+    uint8_t refreshSpinCourse_(SpinPoint *, uint8_t, unsigned long);
+    uint16_t getLinePointY_(uint16_t, uint16_t, uint16_t, uint16_t, uint16_t);
 };
 
 #endif


### PR DESCRIPTION
- data coming from the system `millis()` function remains as unsigned long
- minor changes in documentation

Closes #11 